### PR TITLE
fix/verify sak

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -78,3 +78,7 @@ spec:
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/Henvendelse_v2"
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/SendUtHenvendelse_v1"
+    - name: SAK_ENDPOINTURL
+      value: "https://sak.nais.preprod.local"
+    - name: PDL_API_URL
+      value: "https://pdl-api-q1.dev.intern.nav.no/graphql"

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -77,3 +77,7 @@ spec:
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/Henvendelse_v2"
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/SendUtHenvendelse_v1"
+    - name: SAK_ENDPOINTURL
+      value: "https://sak.nais.adeo.no"
+    - name: PDL_API_URL
+      value: "https://pdl-api.nais.adeo.no/graphql"

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,14 @@
         </dependency>
         <dependency>
             <groupId>no.nav.common</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.common</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.common</groupId>
             <artifactId>auth</artifactId>
         </dependency>
         <dependency>

--- a/src/main/kotlin/no/nav/henvendelse/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/henvendelse/config/ApplicationConfig.kt
@@ -2,6 +2,8 @@ package no.nav.henvendelse.config
 
 import no.nav.common.auth.context.AuthContextHolderThreadLocal
 import no.nav.common.cxf.StsConfig
+import no.nav.common.sts.NaisSystemUserTokenProvider
+import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.common.utils.EnvironmentUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,6 +21,13 @@ class ApplicationConfig {
         .username(EnvironmentUtils.getRequiredProperty(SRV_USERNAME_PROPERTY))
         .password(EnvironmentUtils.getRequiredProperty(SRV_PASSWORD_PROPERTY))
         .build()
+
+    @Bean
+    fun serviceUserProvider(): SystemUserTokenProvider = NaisSystemUserTokenProvider(
+        EnvironmentUtils.getRequiredProperty("SECURITY_TOKEN_SERVICE_DISCOVERY_URL"),
+        EnvironmentUtils.getRequiredProperty(SRV_USERNAME_PROPERTY),
+        EnvironmentUtils.getRequiredProperty(SRV_PASSWORD_PROPERTY)
+    )
 
     @Bean
     fun authContextHolder() = AuthContextHolderThreadLocal.instance()

--- a/src/main/kotlin/no/nav/henvendelse/consumer/pdl/GraphQLClient.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/pdl/GraphQLClient.kt
@@ -1,0 +1,110 @@
+package no.nav.henvendelse.consumer.pdl
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.JavaType
+import no.nav.common.log.MDCConstants
+import no.nav.henvendelse.utils.OkHttpUtils
+import no.nav.henvendelse.utils.TjenestekallLogger
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.slf4j.MDC
+import java.util.*
+
+interface GraphQLVariables
+interface GraphQLResult
+data class GraphQLError(val message: String)
+interface GraphQLRequest<VARIABLES : GraphQLVariables, RETURN_TYPE : GraphQLResult> {
+    val query: String
+    val variables: VARIABLES
+
+    @get:JsonIgnore
+    val expectedReturnType: Class<RETURN_TYPE>
+}
+data class GraphQLResponse<DATA>(
+    val errors: List<GraphQLError>?,
+    val data: DATA?
+)
+
+data class GraphQLClientConfig(
+    val tjenesteNavn: String,
+    val requestConfig: Request.Builder.(callId: String) -> Unit
+)
+
+class GraphQLClient(
+    private val httpClient: OkHttpClient,
+    private val config: GraphQLClientConfig
+) {
+    private val log = TjenestekallLogger.logger
+
+    fun <VARS : GraphQLVariables, DATA : GraphQLResult, REQUEST : GraphQLRequest<VARS, DATA>> execute(
+        request: REQUEST
+    ): GraphQLResponse<DATA> {
+        val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+        try {
+            log.info(
+                """
+                    ${config.tjenesteNavn}-request: $callId
+                    ------------------------------------------------------------------------------------
+                        callId: ${MDC.get(MDCConstants.MDC_CALL_ID)}
+                    ------------------------------------------------------------------------------------
+                """.trimIndent()
+            )
+
+            val requestBody: String = OkHttpUtils.objectMapper.writeValueAsString(request)
+            val httpRequest = Request.Builder()
+                .header("Content-Type", "application/json")
+                .also {
+                    config.requestConfig.invoke(it, callId)
+                }
+                .post(RequestBody.create(MediaType.parse("application/json"), requestBody))
+                .build()
+
+            val httpResponse = httpClient.newCall(httpRequest).execute()
+
+            val body: String? = httpResponse.body()?.string()
+            log.info(
+                """
+                    ${config.tjenesteNavn}-response: $callId
+                    ------------------------------------------------------------------------------------
+                        status: ${httpResponse.code()} 
+                        body: $body
+                    ------------------------------------------------------------------------------------
+                """.trimIndent()
+            )
+
+            val typeReference: JavaType = OkHttpUtils.objectMapper.typeFactory
+                .constructParametricType(GraphQLResponse::class.java, request.expectedReturnType)
+            val response: GraphQLResponse<DATA> = OkHttpUtils.objectMapper.readValue<GraphQLResponse<DATA>>(body, typeReference)
+
+            if (response.errors?.isNotEmpty() == true) {
+                val errorMessages = response.errors.joinToString(", ") { it.message }
+                log.info(
+                    """
+                        ${config.tjenesteNavn}-response: $callId
+                        ------------------------------------------------------------------------------------
+                            status: ${httpResponse.code()} ${response.data}
+                            errors: $errorMessages
+                        ------------------------------------------------------------------------------------
+                    """.trimIndent()
+                )
+                throw Exception(errorMessages)
+            }
+
+            return response
+        } catch (exception: Exception) {
+            log.error(
+                """
+                    ${config.tjenesteNavn}-response: $callId
+                    ------------------------------------------------------------------------------------
+                        exception:
+                        $exception
+                    ------------------------------------------------------------------------------------
+                """.trimIndent()
+            )
+
+            throw exception
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/pdl/PdlConfig.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/pdl/PdlConfig.kt
@@ -1,0 +1,15 @@
+package no.nav.henvendelse.consumer.pdl
+
+import no.nav.common.sts.SystemUserTokenProvider
+import no.nav.common.utils.EnvironmentUtils
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class PdlConfig {
+    @Bean
+    fun pdlService(stsService: SystemUserTokenProvider) = PdlService(
+        url = EnvironmentUtils.getRequiredProperty("PDL_API_URL"),
+        stsService = stsService
+    )
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/pdl/PdlService.kt
@@ -1,0 +1,66 @@
+package no.nav.henvendelse.consumer.pdl
+
+import no.nav.common.rest.client.RestClient
+import no.nav.common.sts.SystemUserTokenProvider
+import no.nav.henvendelse.consumer.pdl.queries.HentAktorIder
+
+class PdlException(message: String, cause: Throwable) : RuntimeException(message, cause)
+
+open class PdlService(
+    private val url: String,
+    private val stsService: SystemUserTokenProvider,
+) {
+    private val graphqlClient = GraphQLClient(
+        RestClient.baseClient(),
+        GraphQLClientConfig(
+            tjenesteNavn = "PDL",
+            requestConfig = { callId ->
+                val appToken: String = stsService.systemUserToken
+                    ?: throw IllegalStateException("Kunne ikke hente ut systemusertoken")
+
+                url(url)
+                header("Nav-Call-Id", callId)
+                header("Nav-Consumer-Id", "henvendelse-api")
+                header("Nav-Consumer-Token", "Bearer $appToken")
+                header("Authorization", "Bearer $appToken")
+                header("Tema", "GEN")
+            }
+        )
+    )
+
+    fun hentAktorIder(fnr: String): List<String>? {
+        return graphqlClient
+            .runCatching {
+                execute(
+                    HentAktorIder(HentAktorIder.Variables(fnr))
+                )
+            }
+            .map { response ->
+                response
+                    .data
+                    ?.hentIdenter
+                    ?.identer
+                    ?.map { it.ident }
+            }
+            .getOrThrow {
+                PdlException("Feil ved uthenting av GT", it)
+            }
+    }
+
+    companion object {
+        fun lastQueryFraFil(name: String): String {
+            return GraphQLClient::class.java
+                .getResource("/pdl/$name.graphql")
+                .readText()
+                .replace("[\n\r]", "")
+        }
+    }
+}
+
+private inline fun <T> Result<T>.getOrThrow(fn: (Throwable) -> Throwable): T {
+    val exception = exceptionOrNull()
+    if (exception != null) {
+        throw fn(exception)
+    }
+    return getOrThrow()
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/pdl/queries/HentAktorIder.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/pdl/queries/HentAktorIder.kt
@@ -1,0 +1,17 @@
+package no.nav.henvendelse.consumer.pdl.queries
+
+import no.nav.henvendelse.consumer.pdl.GraphQLRequest
+import no.nav.henvendelse.consumer.pdl.GraphQLResult
+import no.nav.henvendelse.consumer.pdl.GraphQLVariables
+import no.nav.henvendelse.consumer.pdl.PdlService
+
+class HentAktorIder(override val variables: Variables) :
+    GraphQLRequest<HentAktorIder.Variables, HentAktorIder.Result> {
+    override val query: String = PdlService.lastQueryFraFil("hentAktorIder")
+    override val expectedReturnType: Class<Result> = Result::class.java
+
+    data class Variables(val fnr: String) : GraphQLVariables
+    data class Result(val hentIdenter: Identliste?) : GraphQLResult
+    data class Identliste(val identer: List<IdentInformasjon>)
+    data class IdentInformasjon(val ident: String, val historisk: Boolean)
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakApiImpl.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakApiImpl.kt
@@ -1,6 +1,8 @@
 package no.nav.henvendelse.consumer.sak
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.common.health.HealthCheckResult
+import no.nav.common.health.selftest.SelfTestCheck
 import no.nav.common.rest.client.RestClient
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.henvendelse.utils.AuthorizationInterceptor
@@ -34,6 +36,27 @@ class SakApiImpl(
         val request = Request
             .Builder()
             .url("$baseUrl/api/v1/saker/$saksId")
+            .header("accept", "application/json")
+            .build()
+
+        return fetch(request)
+    }
+
+    override fun ping() = SelfTestCheck("Sak via $baseUrl", true) {
+        try {
+            hentPingSaker()
+            HealthCheckResult.healthy()
+        } catch (e: Throwable) {
+            HealthCheckResult.unhealthy(e)
+        }
+    }
+
+    private fun hentPingSaker(): List<SakDto> {
+        val aktorId = "0000000000000"
+        val tema = "PEN"
+        val request = Request
+            .Builder()
+            .url("$baseUrl/api/v1/saker?aktoerId=$aktorId&tema=$tema")
             .header("accept", "application/json")
             .build()
 

--- a/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakApiImpl.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakApiImpl.kt
@@ -1,0 +1,56 @@
+package no.nav.henvendelse.consumer.sak
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.common.rest.client.RestClient
+import no.nav.common.sts.SystemUserTokenProvider
+import no.nav.henvendelse.utils.AuthorizationInterceptor
+import no.nav.henvendelse.utils.LoggingInterceptor
+import no.nav.henvendelse.utils.OkHttpUtils
+import no.nav.henvendelse.utils.XCorrelationIdInterceptor
+import okhttp3.Request
+import okhttp3.Response
+
+class SakApiImpl(
+    val baseUrl: String = "",
+    val systemTokenProvider: SystemUserTokenProvider
+) : SakApi {
+    val client = RestClient.baseClient().newBuilder()
+        .addInterceptor(XCorrelationIdInterceptor())
+        .addInterceptor(
+            AuthorizationInterceptor {
+                systemTokenProvider.systemUserToken
+            }
+        )
+        .addInterceptor(
+            LoggingInterceptor("Sak") { request ->
+                requireNotNull(request.header("X-Correlation-ID")) {
+                    "Kall uten \"X-Correlation-ID\" er ikke lov"
+                }
+            }
+        )
+        .build()
+
+    override fun hentSak(saksId: String): SakDto {
+        val request = Request
+            .Builder()
+            .url("$baseUrl/api/v1/saker/$saksId")
+            .header("accept", "application/json")
+            .build()
+
+        return fetch(request)
+    }
+
+    private inline fun <reified RESPONSE> fetch(request: Request): RESPONSE {
+        val response: Response = client
+            .newCall(request)
+            .execute()
+
+        val body = response.body()?.string()
+
+        return if (response.code() in 200..299 && body != null) {
+            OkHttpUtils.objectMapper.readValue(body)
+        } else {
+            throw IllegalStateException("Forventet 200-range svar og body fra sak-api, men fikk: ${response.code()} $body")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakConfig.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakConfig.kt
@@ -1,0 +1,17 @@
+package no.nav.henvendelse.consumer.sak
+
+import no.nav.common.sts.SystemUserTokenProvider
+import no.nav.common.utils.EnvironmentUtils
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SakConfig {
+    @Bean
+    fun sakApi(systemTokenProvider: SystemUserTokenProvider): SakApi {
+        return SakApiImpl(
+            EnvironmentUtils.getRequiredProperty("SAK_ENDPOINTURL"),
+            systemTokenProvider
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakDomain.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakDomain.kt
@@ -1,0 +1,18 @@
+package no.nav.henvendelse.consumer.sak
+
+import java.time.OffsetDateTime
+
+interface SakApi {
+    fun hentSak(saksId: String): SakDto
+}
+
+data class SakDto(
+    val id: String? = null,
+    val tema: String? = null, // example: AAP
+    val applikasjon: String? = null, // example: IT01 Kode for applikasjon iht. felles kodeverk
+    val aktoerId: String? = null, // example: 10038999999 Id til aktøren saken gjelder
+    val orgnr: String? = null, // Orgnr til foretaket saken gjelder
+    val fagsakNr: String? = null, // Fagsaknr for den aktuelle saken - hvis aktuelt
+    val opprettetAv: String? = null, // Brukerident til den som opprettet saken
+    val opprettetTidspunkt: OffsetDateTime? = null
+)

--- a/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakDomain.kt
+++ b/src/main/kotlin/no/nav/henvendelse/consumer/sak/SakDomain.kt
@@ -1,8 +1,9 @@
 package no.nav.henvendelse.consumer.sak
 
+import no.nav.henvendelse.utils.Pingable
 import java.time.OffsetDateTime
 
-interface SakApi {
+interface SakApi : Pingable {
     fun hentSak(saksId: String): SakDto
 }
 

--- a/src/main/kotlin/no/nav/henvendelse/rest/common/Verification.kt
+++ b/src/main/kotlin/no/nav/henvendelse/rest/common/Verification.kt
@@ -1,8 +1,21 @@
 package no.nav.henvendelse.rest.common
 
+import no.nav.henvendelse.consumer.pdl.PdlService
+import no.nav.henvendelse.consumer.sak.SakDto
+import no.nav.henvendelse.rest.henvendelseinformasjon.HentHenvendelseResponse
 import java.util.*
 
 object Verification {
+    fun <T> verifyNotNull(value: T?, lazyMessage: () -> String): T {
+        return runCatching {
+            requireNotNull(value)
+        }.fold(
+            onSuccess = { it },
+            onFailure = {
+                throw RestInvalidDataException(lazyMessage())
+            }
+        )
+    }
     fun verifyBehandlingsId(behandlingsId: String) {
         verify(behandlingsId.startsWith("10")) { "BehandlingsId må starte med 10. [$behandlingsId]" }
         verify(behandlingsId.length == 9) { "BehandlingsId må ha lengde 9. [$behandlingsId]" }
@@ -32,6 +45,29 @@ object Verification {
     fun verifyEnhet(enhet: String) {
         verify(enhet.length == 4) { "EnhetId må ha lengde 4. [$enhet]" }
         verify(enhet.isDigits()) { "EnhetId skal bare inneholde tall. [$enhet]" }
+    }
+
+    fun verifySammeEierskapAvSakOgHenvendelse(pdlService: PdlService, sak: SakDto, henvendelse: HentHenvendelseResponse) {
+        val sakAktorId = verifyNotNull(sak.aktoerId) { "Saksid ${sak.id} hadde ingen aktorId" }
+        val henvendelseAktorId = verifyNotNull(henvendelse.henvendelse.aktorId) {
+            "Henvendelse ${henvendelse.henvendelse.behandlingsId} hadde ingen lagret aktorId"
+        }
+
+        if (sakAktorId == henvendelseAktorId) {
+            return
+        } else {
+            val fnr = henvendelse.henvendelse.fnr
+            val aktorIder = fnr?.let { pdlService.hentAktorIder(it) } ?: emptyList()
+            verify(aktorIder.contains(sakAktorId)) {
+                """
+                    Henvendelse/Sak hadde forskjellige aktorId lagret, og oppslags vha PDL feilet.
+                    Henvendelse-fnr: $fnr
+                    Henvendelse-aktorId: $henvendelseAktorId
+                    SakAktorId: $sakAktorId
+                    PdlAktorId: ${aktorIder.joinToString(", ")}
+                """.trimIndent()
+            }
+        }
     }
 
     fun verify(valid: Boolean, lazyMessage: () -> String) {

--- a/src/main/kotlin/no/nav/henvendelse/utils/OkHttpUtils.kt
+++ b/src/main/kotlin/no/nav/henvendelse/utils/OkHttpUtils.kt
@@ -1,0 +1,105 @@
+package no.nav.henvendelse.utils
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.common.log.MDCConstants
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import okio.Buffer
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import java.util.*
+
+object OkHttpUtils {
+    val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .registerModule(Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, false)
+}
+
+class LoggingInterceptor(val name: String, val callIdExtractor: (Request) -> String) : Interceptor {
+    private val log = LoggerFactory.getLogger(LoggingInterceptor::class.java)
+    private fun Request.peekContent(): String? {
+        val copy = this.newBuilder().build()
+        val buffer = Buffer()
+        copy.body()?.writeTo(buffer)
+
+        return buffer.readUtf8()
+    }
+
+    private fun Response.peekContent(): String? {
+        return this.peekBody(Long.MAX_VALUE).string()
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val callId = callIdExtractor(request)
+        val requestBody = request.peekContent()
+
+        TjenestekallLogger.info(
+            "$name-request: $callId",
+            mapOf(
+                "url" to request.url().toString(),
+                "headers" to request.headers().names().joinToString(", "),
+                "body" to requestBody
+            )
+        )
+
+        val response: Response = runCatching { chain.proceed(request) }
+            .onFailure { exception ->
+                log.error("$name-response-error (ID: $callId)", exception)
+                TjenestekallLogger.error(
+                    "$name-response-error: $callId",
+                    mapOf(
+                        "exception" to exception
+                    )
+                )
+            }
+            .getOrThrow()
+
+        val responseBody = response.peekContent()
+
+        if (response.code() in 200..299) {
+            TjenestekallLogger.info(
+                "$name-response: $callId",
+                mapOf(
+                    "status" to "${response.code()} ${response.message()}",
+                    "body" to responseBody
+                )
+            )
+        } else {
+            TjenestekallLogger.error(
+                "$name-response-error: $callId",
+                mapOf(
+                    "status" to "${response.code()} ${response.message()}",
+                    "request" to request,
+                    "body" to responseBody
+                )
+            )
+        }
+        return response
+    }
+}
+
+open class HeadersInterceptor(val headersProvider: () -> Map<String, String>) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val builder = chain.request()
+            .newBuilder()
+        headersProvider()
+            .forEach { (name, value) -> builder.addHeader(name, value) }
+
+        return chain.proceed(builder.build())
+    }
+}
+class XCorrelationIdInterceptor() : HeadersInterceptor({
+    mapOf("X-Correlation-ID" to getCallId())
+})
+class AuthorizationInterceptor(val tokenProvider: () -> String) : HeadersInterceptor({
+    mapOf("Authorization" to "Bearer ${tokenProvider()}")
+})
+
+fun getCallId(): String = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()

--- a/src/main/kotlin/no/nav/henvendelse/utils/TjenestekallLogger.kt
+++ b/src/main/kotlin/no/nav/henvendelse/utils/TjenestekallLogger.kt
@@ -1,0 +1,24 @@
+package no.nav.henvendelse.utils
+
+import org.slf4j.LoggerFactory
+import java.lang.StringBuilder
+
+object TjenestekallLogger {
+    val logger = LoggerFactory.getLogger("SecureLog")
+
+    fun info(header: String, fields: Map<String, Any?>) = logger.info(format(header, fields))
+    fun warn(header: String, fields: Map<String, Any?>) = logger.warn(format(header, fields))
+    fun error(header: String, fields: Map<String, Any?>) = logger.error(format(header, fields))
+    fun error(header: String, fields: Map<String, Any?>, throwable: Throwable) = logger.error(format(header, fields), throwable)
+
+    private fun format(header: String, fields: Map<String, Any?>): String {
+        val sb = StringBuilder()
+        sb.appendln(header)
+        sb.appendln("------------------------------------------------------------------------------------")
+        fields.forEach { (key, value) ->
+            sb.appendln("$key: $value")
+        }
+        sb.appendln("------------------------------------------------------------------------------------")
+        return sb.toString()
+    }
+}

--- a/src/main/resources/pdl/.graphqlconfig
+++ b/src/main/resources/pdl/.graphqlconfig
@@ -1,0 +1,11 @@
+{
+  "name": "pdl-api",
+  "schemaPath": "schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "PDL GraphQL Endpoint": {
+        "introspect": false
+      }
+    }
+  }
+}

--- a/src/main/resources/pdl/hentAktorIder.graphql
+++ b/src/main/resources/pdl/hentAktorIder.graphql
@@ -1,0 +1,8 @@
+query($ident: ID!){
+    hentIdenter(ident: $ident, grupper: [AKTORID], historikk: true) {
+        identer {
+            ident
+            historisk
+        }
+    }
+}

--- a/src/main/resources/pdl/schema.graphql
+++ b/src/main/resources/pdl/schema.graphql
@@ -1,0 +1,669 @@
+# ISO-8601 representasjon for en kalenderdato. YYYY-MM-DD. Eksempel: 2018-01-01.
+scalar Date
+
+# ISO-8601 representasjon for en kalenderdato med tid, trunkert til nærmeste sekund. YYYY-MM-DD'T'hh:mm:ss. Eksempel: 2018-01-01T12:00:00.
+scalar DateTime
+
+# Schema parser kjenner ikke til Typen long  men den er støttet av graphql-java, så definerer den her for at schema skal validere.
+scalar Long
+
+schema {
+    query: Query
+}
+
+type Query {
+    hentPerson(ident: ID!): Person
+    hentPersonBolk(identer: [ID!]!): [HentPersonBolkResult!]!
+    hentIdenter(ident: ID!, grupper: [IdentGruppe!], historikk: Boolean = false): Identliste
+    hentIdenterBolk(identer: [ID!]!, grupper: [IdentGruppe!], historikk: Boolean = false): [HentIdenterBolkResult!]!
+    hentGeografiskTilknytning(ident: ID!): GeografiskTilknytning
+    sokPerson(criteria:[Criterion], paging:Paging): SearchResult
+}
+
+type Identliste {
+    identer: [IdentInformasjon!]!
+}
+
+type HentIdenterBolkResult {
+    ident: String!
+    identer: [IdentInformasjon!]
+    code: String!
+}
+
+type IdentInformasjon {
+    ident: String!
+    gruppe: IdentGruppe!
+    historisk: Boolean!
+}
+
+enum IdentGruppe {
+    AKTORID,
+    FOLKEREGISTERIDENT,
+    NPID
+}
+
+type HentPersonBolkResult {
+    ident: String!
+    person: Person
+    code: String!
+}
+
+type Person {
+    adressebeskyttelse(historikk: Boolean = false): [Adressebeskyttelse!]!
+    bostedsadresse(historikk: Boolean = false): [Bostedsadresse!]!
+    deltBosted(historikk: Boolean = false): [DeltBosted!]!
+    doedfoedtBarn: [DoedfoedtBarn!]!
+    doedsfall: [Doedsfall!]!
+    falskIdentitet: FalskIdentitet
+    familierelasjoner: [Familierelasjon!]!
+    foedsel: [Foedsel!]!
+    folkeregisteridentifikator(historikk: Boolean = false): [Folkeregisteridentifikator!]!
+    folkeregisterpersonstatus(historikk: Boolean = false): [Folkeregisterpersonstatus!]!
+    foreldreansvar(historikk: Boolean = false): [Foreldreansvar!]!
+    fullmakt(historikk: Boolean = false): [Fullmakt!]!
+    identitetsgrunnlag(historikk: Boolean = false): [Identitetsgrunnlag!]!
+    kjoenn(historikk: Boolean = false): [Kjoenn!]!
+    kontaktadresse(historikk: Boolean = false): [Kontaktadresse!]!
+    kontaktinformasjonForDoedsbo(historikk: Boolean = false): [KontaktinformasjonForDoedsbo!]!
+    navn(historikk: Boolean = false): [Navn!]!
+    opphold(historikk: Boolean = false):[Opphold!]!
+    oppholdsadresse(historikk: Boolean = false):[Oppholdsadresse!]!
+    sikkerhetstiltak:[Sikkerhetstiltak!]!
+    sivilstand(historikk: Boolean = false):[Sivilstand!]!
+    statsborgerskap(historikk: Boolean = false): [Statsborgerskap!]!
+    telefonnummer: [Telefonnummer!]!
+    tilrettelagtKommunikasjon:[TilrettelagtKommunikasjon!]!
+    utenlandskIdentifikasjonsnummer(historikk: Boolean = false): [UtenlandskIdentifikasjonsnummer!]!
+    innflyttingTilNorge: [InnflyttingTilNorge!]!
+    utflyttingFraNorge: [UtflyttingFraNorge!]!
+    vergemaalEllerFremtidsfullmakt(historikk: Boolean = false): [VergemaalEllerFremtidsfullmakt!]!
+}
+
+type DeltBosted {
+    startdatoForKontrakt: Date!
+    sluttdatoForKontrakt: Date
+    @deprecated(reason: "Flyttet til adresser rett under")
+    adresseNode: AdresseNode!
+
+    coAdressenavn: String
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    utenlandskAdresse: UtenlandskAdresse
+    ukjentBosted: UkjentBosted
+
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type Bostedsadresse {
+    angittFlyttedato: Date
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+
+    coAdressenavn: String
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    utenlandskAdresse: UtenlandskAdresse
+    ukjentBosted: UkjentBosted
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Oppholdsadresse {
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    oppholdsadressedato: Date @deprecated(reason: "Mappes til gyldigFraOgMed. Dette feltet er nå overflødig vil bli fjernet")
+
+    coAdressenavn: String
+    utenlandskAdresse: UtenlandskAdresse
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    oppholdAnnetSted: String
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Kontaktadresse {
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    type: KontaktadresseType!
+
+    coAdressenavn: String
+    postboksadresse: Postboksadresse
+    vegadresse: Vegadresse
+    postadresseIFrittFormat: PostadresseIFrittFormat
+    utenlandskAdresse: UtenlandskAdresse
+    utenlandskAdresseIFrittFormat: UtenlandskAdresseIFrittFormat
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum KontaktadresseType {
+    Innland,
+    Utland
+}
+
+type Vegadresse {
+    matrikkelId: Long
+    husnummer: String
+    husbokstav: String
+    bruksenhetsnummer: String
+    adressenavn: String
+    kommunenummer: String
+    bydelsnummer: String
+    tilleggsnavn: String
+    postnummer: String
+    koordinater: Koordinater
+}
+
+type Matrikkeladresse {
+    matrikkelId: Long
+    bruksenhetsnummer: String
+    tilleggsnavn: String
+    postnummer: String
+    kommunenummer: String
+    koordinater: Koordinater
+}
+
+type UkjentBosted {
+    bostedskommune: String
+}
+
+type UtenlandskAdresse {
+    adressenavnNummer: String
+    bygningEtasjeLeilighet: String
+    postboksNummerNavn: String
+    postkode: String
+    bySted: String
+    regionDistriktOmraade: String
+    landkode: String!
+}
+
+type UtenlandskAdresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    postkode: String
+    byEllerStedsnavn: String
+    landkode: String!
+}
+
+type Postboksadresse {
+    postbokseier: String
+    postboks: String!
+    postnummer: String
+}
+
+type PostadresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    postnummer: String
+}
+
+type Koordinater {
+    x: Float
+    y: Float
+    z: Float
+    kvalitet: Int
+}
+
+type AdresseNode {
+    coAdressenavn: String
+    adressegradering: String
+}
+
+type FalskIdentitet {
+    erFalsk: Boolean!
+    rettIdentitetVedIdentifikasjonsnummer: String
+    rettIdentitetErUkjent: Boolean
+    rettIdentitetVedOpplysninger: FalskIdentitetIdentifiserendeInformasjon
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type FalskIdentitetIdentifiserendeInformasjon {
+    personnavn: Personnavn!
+    foedselsdato: Date
+    statsborgerskap: [String!]!
+    kjoenn: KjoennType
+}
+
+type KontaktinformasjonForDoedsbo {
+    skifteform: KontaktinformasjonForDoedsboSkifteform!
+    attestutstedelsesdato: Date!
+    personSomKontakt: KontaktinformasjonForDoedsboPersonSomKontakt
+    advokatSomKontakt: KontaktinformasjonForDoedsboAdvokatSomKontakt
+    organisasjonSomKontakt: KontaktinformasjonForDoedsboOrganisasjonSomKontakt
+    adresse: KontaktinformasjonForDoedsboAdresse!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum KontaktinformasjonForDoedsboSkifteform {
+    OFFENTLIG
+    ANNET
+}
+
+type KontaktinformasjonForDoedsboPersonSomKontakt {
+    foedselsdato: Date
+    personnavn: Personnavn
+    identifikasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboAdvokatSomKontakt {
+    personnavn: Personnavn!
+    organisasjonsnavn: String
+    organisasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboOrganisasjonSomKontakt {
+    kontaktperson: Personnavn
+    organisasjonsnavn: String!
+    organisasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboAdresse {
+    adresselinje1: String!
+    adresselinje2: String
+    poststedsnavn: String!
+    postnummer: String!
+    landkode: String
+}
+
+type UtenlandskIdentifikasjonsnummer {
+    identifikasjonsnummer: String!
+    utstederland: String!
+    opphoert: Boolean!
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Adressebeskyttelse {
+    gradering: AdressebeskyttelseGradering!
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum AdressebeskyttelseGradering {
+    STRENGT_FORTROLIG_UTLAND,
+    STRENGT_FORTROLIG,
+    FORTROLIG,
+    UGRADERT
+}
+
+type Foedsel {
+    foedselsaar: Int
+    foedselsdato: Date
+    foedeland: String
+    foedested: String
+    foedekommune: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Kjoenn {
+    kjoenn: KjoennType
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Doedsfall {
+    doedsdato: Date
+    metadata: Metadata!
+    folkeregistermetadata: Folkeregistermetadata
+}
+
+type Familierelasjon {
+    relatertPersonsIdent: String!
+    relatertPersonsRolle: Familierelasjonsrolle!
+    minRolleForPerson: Familierelasjonsrolle
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type DoedfoedtBarn {
+    dato: Date
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Familierelasjonsrolle {
+    BARN,
+    MOR,
+    FAR,
+    MEDMOR
+}
+
+type Folkeregisterpersonstatus {
+    status: String!
+    forenkletStatus: String!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type GeografiskTilknytning {
+    gtType: GtType!
+    gtKommune: String
+    gtBydel: String
+    gtLand: String
+    regel: String!
+}
+
+enum GtType {
+    KOMMUNE,
+    BYDEL,
+    UTLAND,
+    UDEFINERT
+}
+
+type Navn {
+    fornavn: String!
+    mellomnavn: String
+    etternavn: String!
+    forkortetNavn: String
+    originaltNavn: OriginaltNavn
+    gyldigFraOgMed: Date
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type OriginaltNavn {
+    fornavn: String
+    mellomnavn: String
+    etternavn: String
+}
+
+type Personnavn {
+    fornavn: String!
+    mellomnavn: String
+    etternavn: String!
+}
+
+enum KjoennType {
+    MANN, KVINNE, UKJENT
+}
+
+type Identitetsgrunnlag {
+    status: Identitetsgrunnlagsstatus!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Identitetsgrunnlagsstatus {
+    IKKE_KONTROLLERT
+    KONTROLLERT,
+    INGEN_STATUS
+}
+
+type Folkeregistermetadata {
+    ajourholdstidspunkt: DateTime
+    gyldighetstidspunkt: DateTime
+    opphoerstidspunkt: DateTime
+    kilde: String
+    aarsak: String
+    sekvens: Int
+}
+
+type Telefonnummer {
+    landskode: String!
+    nummer: String!
+    prioritet: Int!
+    metadata: Metadata!
+}
+
+type TilrettelagtKommunikasjon {
+    talespraaktolk: Tolk
+    tegnspraaktolk: Tolk
+    metadata: Metadata!
+}
+
+type Tolk {
+    spraak: String
+}
+
+enum FullmaktsRolle {
+    FULLMAKTSGIVER,
+    FULLMEKTIG
+}
+
+type Fullmakt {
+    motpartsPersonident: String!
+    motpartsRolle: FullmaktsRolle!
+    omraader: [String!]!
+    gyldigFraOgMed: Date!
+    gyldigTilOgMed: Date!
+    metadata: Metadata!
+}
+
+type Folkeregisteridentifikator {
+    identifikasjonsnummer: String!
+    status: String!
+    type: String!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type SikkerhetstiltakKontaktperson {
+    personident: String!
+    enhet: String!
+}
+
+type Sikkerhetstiltak {
+    tiltakstype: String!
+    beskrivelse: String!
+    kontaktperson: SikkerhetstiltakKontaktperson
+    gyldigFraOgMed: Date!
+    gyldigTilOgMed: Date!
+    metadata: Metadata!
+}
+
+type Statsborgerskap {
+    land: String!
+    gyldigFraOgMed: Date
+    gyldigTilOgMed: Date
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Opphold {
+    type: Oppholdstillatelse!
+    oppholdFra: Date
+    oppholdTil: Date
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Oppholdstillatelse {
+    MIDLERTIDIG
+    PERMANENT
+    OPPLYSNING_MANGLER
+}
+
+type Sivilstand {
+    type: Sivilstandstype!
+    gyldigFraOgMed: Date
+    myndighet: String
+    kommune: String
+    sted: String
+    utland: String
+    relatertVedSivilstand: String
+    bekreftelsesdato: String
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum Sivilstandstype {
+    UOPPGITT
+    UGIFT
+    GIFT
+    ENKE_ELLER_ENKEMANN
+    SKILT
+    SEPARERT
+    REGISTRERT_PARTNER
+    SEPARERT_PARTNER
+    SKILT_PARTNER
+    GJENLEVENDE_PARTNER
+}
+
+type InnflyttingTilNorge {
+    fraflyttingsland: String
+    fraflyttingsstedIUtlandet: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type UtflyttingFraNorge {
+    tilflyttingsland: String
+    tilflyttingsstedIUtlandet: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type VergeEllerFullmektig {
+    navn: Personnavn
+    motpartsPersonident: String
+    omfang: String
+    omfangetErInnenPersonligOmraade: Boolean!
+}
+
+type VergemaalEllerFremtidsfullmakt {
+    type: String
+    embete: String
+    vergeEllerFullmektig: VergeEllerFullmektig!
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Foreldreansvar {
+    ansvar: String
+    ansvarlig: String
+    ansvarligUtenIdentifikator: RelatertBiPerson
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type RelatertBiPerson {
+    navn: Personnavn
+    foedselsdato: Date
+    statsborgerskap: String
+    kjoenn: KjoennType
+}
+
+type Metadata {
+    # I PDL så får alle forekomster av en opplysning en ID som representerer dens unike forekomst.
+    # F.eks, så vil en Opprett ha ID X, korriger ID Y (der hvor den spesifiserer at den korrigerer X).
+    # Dersom en opplysning ikke er lagret i PDL, så vil denne verdien ikke være utfylt.
+    opplysningsId: String
+
+    # Master refererer til hvem som eier opplysningen, f.eks så har PDL en kopi av Folkeregisteret, da vil master være FREG og eventuelle endringer på dette må gå via Folkeregisteret (API mot dem eller andre rutiner).
+    master: String!
+
+    # En liste over alle endringer som har blitt utført over tid.
+    # Vær obs på at denne kan endre seg og man burde takle at det finnes flere korrigeringer i listen, så dersom man ønsker å kun vise den siste, så må man selv filtrere ut dette.
+    # Det kan også ved svært få tilfeller skje at opprett blir fjernet. F.eks ved splitt tilfeller av identer. Dette skal skje i svært få tilfeller. Dersom man ønsker å presentere opprettet tidspunktet, så blir det tidspunktet på den første endringen.
+    endringer: [Endring!]!
+
+    # Feltet betegner hvorvidt dette er en funksjonelt historisk opplysning, for eksempel en tidligere fraflyttet adresse eller et foreldreansvar som er utløpt fordi barnet har fylt 18 år.
+    # I de fleste tilfeller kan dette utledes ved å se på de andre feltene i opplysningen. Dette er imidlertid ikke alltid tilfellet, blant annet for foreldreansvar.
+    # Feltet bør brukes av konsumenter som henter informasjon fra GraphQL med historikk, men som også trenger å utlede gjeldende informasjon.
+    historisk: Boolean!
+}
+
+# Endring som har blitt utført på opplysningen. F.eks: Opprett -> Korriger -> Korriger
+type Endring {
+    # Hvilke type endring som har blitt utført.
+    type: Endringstype!
+    # Tidspunktet for registrering.
+    registrert: DateTime!
+    # Hvem endringen har blitt utført av, ofte saksbehandler (f.eks Z990200), men kan også være system (f.eks srvXXXX). Denne blir satt til "Folkeregisteret" for det vi får fra dem.
+    registrertAv: String!
+    # Hvilke system endringen har kommet fra (f.eks srvXXX). Denne blir satt til "FREG" for det vi får fra Folkeregisteret.
+    systemkilde: String!
+    # Opphavet til informasjonen. I NAV blir dette satt i forbindelse med registrering (f.eks: Sykehuskassan).
+    # Fra Folkeregisteret får vi opphaven til dems opplysning, altså NAV, UDI, Politiet, Skatteetaten o.l.. Fra Folkeregisteret kan det også være tekniske navn som: DSF_MIGRERING, m.m..
+    kilde: String!
+}
+
+enum Endringstype {
+    OPPRETT
+    KORRIGER
+    OPPHOER
+}
+
+input Criterion {
+    fieldName:String!
+    searchRule:SearchRule!
+    searchHistorical:Boolean
+}
+
+input SearchRule {
+    exists:String,
+    notEquals:String,
+    equals:String,
+    contains:String,
+    fuzzy:String,
+    wildcard:String,
+    startsWith:String,
+    regex:String,
+    after:String,
+    before:String,
+    lessThan:String,
+    greaterThan:String,
+    from:String,
+    to:String,
+    fromExcluding:String,
+    toExcluding:String,
+
+    #extra query parameters (can not be used as queries by them self)
+    caseSensitive:Boolean,
+    disablePhonetic:Boolean,
+    boost:Float
+}
+
+input Paging {
+    pageNumber:Int = 1,
+    resultsPerPage:Int = 10,
+    sortBy:[SearchSorting]
+}
+
+input SearchSorting {
+    fieldName:String!
+    direction:Direction!
+}
+enum Direction {
+    ASC,
+    DESC
+}
+type SearchResult {
+    hits : [SearchHit!]!
+    pageNumber:Int,
+    totalPages:Int
+    totalHits:Int
+
+}
+type SearchHit {
+    person :Person,
+    identer(historikk: Boolean = false): [IdentInformasjon!]!,
+    score :Float
+    highlights:[SearchHighlight]
+}
+type SearchHighlight {
+    opplysning:String
+    opplysningsId: String
+    historisk: Boolean
+    matches:[SearchMatch]
+}
+type SearchMatch {
+    field:String!
+    type: String
+    fragments: [String]
+}

--- a/src/test/kotlin/no/nav/henvendelse/rest/behandlehenvendelse/BehandleHenvendelseControllerMvcTest.kt
+++ b/src/test/kotlin/no/nav/henvendelse/rest/behandlehenvendelse/BehandleHenvendelseControllerMvcTest.kt
@@ -5,7 +5,15 @@ import assertk.assertions.*
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.verify
+import no.nav.henvendelse.consumer.pdl.PdlService
+import no.nav.henvendelse.consumer.sak.SakApi
+import no.nav.henvendelse.consumer.sak.SakDto
+import no.nav.melding.domene.brukerdialog.behandlingsinformasjon.v1.XMLHenvendelse
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v1.behandlehenvendelse.BehandleHenvendelsePortType
+import no.nav.tjeneste.domene.brukerdialog.henvendelse.v2.henvendelse.HenvendelsePortType
+import no.nav.tjeneste.domene.brukerdialog.henvendelse.v2.meldinger.WSHentHenvendelseRequest
+import no.nav.tjeneste.domene.brukerdialog.henvendelse.v2.meldinger.WSHentHenvendelseResponse
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -24,6 +32,15 @@ internal class BehandleHenvendelseControllerMvcTest {
 
     @MockkBean
     lateinit var porttype: BehandleHenvendelsePortType
+
+    @MockkBean
+    lateinit var sakApi: SakApi
+
+    @MockkBean
+    lateinit var pdlService: PdlService
+
+    @MockkBean
+    lateinit var henvendelsePorttype: HenvendelsePortType
 
     @Test
     fun `returnerer 400 om request ikke er i henhold til kontrakten (må ha en request body)`() {
@@ -85,6 +102,130 @@ internal class BehandleHenvendelseControllerMvcTest {
         }
             .isFailure()
             .hasCause(IllegalStateException("Noe gikk feil"))
+    }
+
+    @Test
+    fun `journalføring på sak skal fungere om det er samsvar mellom sak og henvendelse`() {
+        every { sakApi.hentSak(any()) } returns SakDto(aktoerId = "00012345678910")
+        every { henvendelsePorttype.hentHenvendelse(any()) } returns WSHentHenvendelseResponse()
+            .withAny(XMLHenvendelse().withAktorId("00012345678910").withFnr("12345678910"))
+        every { porttype.knyttBehandlingskjedeTilSak(any(), any(), any(), any()) } returns Unit
+
+        mockMvc
+            .post(
+                url = "/api/v1/behandlehenvendelse/knyttbehandlingskjedetilsak",
+                body = mapOf(
+                    "behandlingskjedeId" to "10ACBDEF0",
+                    "saksId" to "123465",
+                    "temakode" to "OPP",
+                    "journalforendeEnhet" to "4100"
+                ),
+                assertions = {
+                    assertThat(status).isEqualTo(200)
+                    verify { sakApi.hentSak("123465") }
+                    verify { henvendelsePorttype.hentHenvendelse(WSHentHenvendelseRequest().withBehandlingsId("10ACBDEF0")) }
+                }
+            )
+    }
+
+    @Test
+    fun `journalføring på sak skal fungere om pdl mener aktorIden er endret`() {
+        every { sakApi.hentSak(any()) } returns SakDto(aktoerId = "00012345678910")
+        every { henvendelsePorttype.hentHenvendelse(any()) } returns WSHentHenvendelseResponse()
+            .withAny(XMLHenvendelse().withAktorId("12345678910000").withFnr("12345678910"))
+        every { porttype.knyttBehandlingskjedeTilSak(any(), any(), any(), any()) } returns Unit
+        every { pdlService.hentAktorIder(any()) } returns listOf("00012345678910", "12345678910000")
+
+        mockMvc
+            .post(
+                url = "/api/v1/behandlehenvendelse/knyttbehandlingskjedetilsak",
+                body = mapOf(
+                    "behandlingskjedeId" to "10ACBDEF0",
+                    "saksId" to "123465",
+                    "temakode" to "OPP",
+                    "journalforendeEnhet" to "4100"
+                ),
+                assertions = {
+                    assertThat(status).isEqualTo(200)
+                    verify { sakApi.hentSak("123465") }
+                    verify { henvendelsePorttype.hentHenvendelse(WSHentHenvendelseRequest().withBehandlingsId("10ACBDEF0")) }
+                    verify { pdlService.hentAktorIder("12345678910") }
+                }
+            )
+    }
+
+    @Test
+    fun `journalføring på sak skal feile om sak ikke har eierskap`() {
+        every { sakApi.hentSak(any()) } returns SakDto(id = "1234")
+        every { henvendelsePorttype.hentHenvendelse(any()) } returns WSHentHenvendelseResponse()
+            .withAny(XMLHenvendelse().withAktorId("12345678910000").withFnr("12345678910"))
+
+        mockMvc
+            .post(
+                url = "/api/v1/behandlehenvendelse/knyttbehandlingskjedetilsak",
+                body = mapOf(
+                    "behandlingskjedeId" to "10ACBDEF0",
+                    "saksId" to "123465",
+                    "temakode" to "OPP",
+                    "journalforendeEnhet" to "4100"
+                ),
+                assertions = {
+                    assertThat(status).isEqualTo(406)
+                    assertThat(errorMessage)
+                        .isNotNull()
+                        .contains("Saksid 1234 hadde ingen aktorId")
+                }
+            )
+    }
+
+    @Test
+    fun `journalføring på sak skal feile om henvendelse ikke har eierskap`() {
+        every { sakApi.hentSak(any()) } returns SakDto(aktoerId = "12345678910000")
+        every { henvendelsePorttype.hentHenvendelse(any()) } returns WSHentHenvendelseResponse()
+            .withAny(XMLHenvendelse().withBehandlingsId("12345ABBA"))
+
+        mockMvc
+            .post(
+                url = "/api/v1/behandlehenvendelse/knyttbehandlingskjedetilsak",
+                body = mapOf(
+                    "behandlingskjedeId" to "10ACBDEF0",
+                    "saksId" to "123465",
+                    "temakode" to "OPP",
+                    "journalforendeEnhet" to "4100"
+                ),
+                assertions = {
+                    assertThat(status).isEqualTo(406)
+                    assertThat(errorMessage)
+                        .isNotNull()
+                        .contains("Henvendelse 12345ABBA hadde ingen lagret aktorId")
+                }
+            )
+    }
+
+    @Test
+    fun `journalføring på sak skal feile om pdl ikke kan mappe fnr til saks aktørid`() {
+        every { sakApi.hentSak(any()) } returns SakDto(aktoerId = "00012345678910")
+        every { henvendelsePorttype.hentHenvendelse(any()) } returns WSHentHenvendelseResponse()
+            .withAny(XMLHenvendelse().withAktorId("12345678910000").withFnr("12345678910"))
+        every { porttype.knyttBehandlingskjedeTilSak(any(), any(), any(), any()) } returns Unit
+        every { pdlService.hentAktorIder(any()) } returns listOf("000987654321", "987654321000")
+
+        mockMvc
+            .post(
+                url = "/api/v1/behandlehenvendelse/knyttbehandlingskjedetilsak",
+                body = mapOf(
+                    "behandlingskjedeId" to "10ACBDEF0",
+                    "saksId" to "123465",
+                    "temakode" to "OPP",
+                    "journalforendeEnhet" to "4100"
+                ),
+                assertions = {
+                    assertThat(status).isEqualTo(406)
+                    assertThat(errorMessage)
+                        .isNotNull()
+                        .contains("Henvendelse/Sak hadde forskjellige aktorId lagret, og oppslags vha PDL feilet.")
+                }
+            )
     }
 
     private fun MockMvc.post(url: String, body: Any? = null, assertions: (MockHttpServletResponse.() -> Unit)? = null) {


### PR DESCRIPTION
- [KAIZEN-0] legge til pdl-integrasjon
  vi må kunne hente ut alle brukers aktørIder for å sikre eierskap om henvendelse har utdatert info
- [KAIZEN-0] legge til sak-integrasjon
  vi må kunne hente ut en saks eierskap for å gjøre verifiseringen
- [KAIZEN-0] legge til verifikasjon av eierskap av sak
  ved journalføring hentes sak og henvendelse ut, om aktørId for sak og henvendelse stemmer overens antar vi at ting er i orden. 
  Hvis ikke henter vi ut fullstendig liste fra PDL slik at vi kan sjekke om det har vært endringer i aktørIden